### PR TITLE
Round load to 1 decimal place in detail view

### DIFF
--- a/lib/traindown_viewer.dart
+++ b/lib/traindown_viewer.dart
@@ -125,7 +125,7 @@ class TraindownViewer extends StatelessWidget {
         Expanded(
             child: Text.rich(
                 TextSpan(
-                  text: p.load.toString(),
+                  text: num.parse(p.load.toStringAsFixed(1)).toString(),
                   style: Theme.of(context).textTheme.bodyText1,
                   children: <TextSpan>[
                     TextSpan(


### PR DESCRIPTION
You can end up with some flaky float math leading to numbers like `42.40000000000000006` being displayed.

![WhatsApp Image 2024-02-09 at 08 04 43](https://github.com/traindown/transponder/assets/2671067/78ba4d0d-e05a-42d4-a6a1-90909e25d435)
![WhatsApp Image 2024-02-09 at 08 04 44](https://github.com/traindown/transponder/assets/2671067/3cf45074-7bfd-41dc-80c8-1a72cdce4d0e)
